### PR TITLE
feat(pages): add custom 404 Not Found page

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,46 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import React from 'react'
+import { Layout } from '../components/Layout/Layout'
+import { LinksList } from '../model/site/LinksList'
+
+export default function NotFound({
+  pageTitle = '404 - Page Not Found',
+  description = '404 - Page Not Found Description',
+}) {
+  return (
+    <>
+      <Head>
+        <title>{pageTitle}</title>
+        <meta name='description' content={description} />
+        <meta name='og:description' content={description} />
+
+        {/* Open Graph */}
+        <meta name='og:title' content={pageTitle} key='ogtitle' />
+        <meta name='og:description' content={description} />
+      </Head>
+
+      <Layout
+        title={
+          <div className='flex items-baseline flex-grow px-2 mx-2 space-x-3'>
+            <div className='text-base font-bold'>404 - Page Not Found</div>
+            <div className='text-sm'>{process.env.NEXT_PUBLIC_SITE_NAME}</div>
+          </div>
+        }
+        menuItems={Object.values(LinksList)}
+      >
+        <div className='flex items-center justify-center w-full h-screen p-4 h-100 md:container md:mx-auto md:px-6'>
+          <div className='block text-center'>
+            <h1 className='pb-4 text-xl font-bold'>404 - Page Not Found</h1>
+            {/* <p>
+              The route <strong>{router.asPath}</strong> does not exist.
+            </p> */}
+            <Link href='/'>
+              <button className='btn btn-outline btn-accent'>Go back home</button>
+            </Link>
+          </div>
+        </div>
+      </Layout>
+    </>
+  )
+}

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -32,9 +32,6 @@ export default function NotFound({
         <div className='flex items-center justify-center w-full h-screen p-4 h-100 md:container md:mx-auto md:px-6'>
           <div className='block text-center'>
             <h1 className='pb-4 text-xl font-bold'>404 - Page Not Found</h1>
-            {/* <p>
-              The route <strong>{router.asPath}</strong> does not exist.
-            </p> */}
             <Link href='/'>
               <button className='btn btn-outline btn-accent'>Go back home</button>
             </Link>


### PR DESCRIPTION
## O que foi feito

Cria a página customizada `src/pages/404.tsx` do Next.js para rotas inexistentes. A tela usa o `Layout` padrão do site, define meta tags (title, description, Open Graph) e oferece um CTA claro para voltar à home.

## Por que foi feito

Sem um `404.tsx` próprio, o Next.js exibe a página de erro genérica — fora da identidade visual do projeto e sem caminho óbvio de recuperação para o usuário. Precisávamos de:

1. **Experiência consistente** — mesma navegação/layout das demais páginas
2. **Saída clara** — botão “Go back home” para o usuário não ficar preso
3. **SEO / compartilhamento** — title e Open Graph adequados quando a URL inválida for indexada ou compartilhada

## Como testar

- [ ] Rodar `yarn dev` e acessar uma rota inexistente (ex.: `/esta-rota-nao-existe`)
- [ ] Confirmar que a página customizada aparece (não a 404 default do Next)
- [ ] Verificar título da aba / meta description no DevTools
- [ ] Clicar em “Go back home” e confirmar redirecionamento para `/`
- [ ] Confirmar que o menu do `Layout` continua navegável na 404
- [ ] Caso edge: rota com query string inválida (ex.: `/foo?bar=1`) — ainda deve renderizar a 404

## Mudanças relevantes

- Novo arquivo `src/pages/404.tsx` — Next.js Pages Router reconhece automaticamente como página de Not Found
- Reutiliza `Layout` + `LinksList` (sem layout paralelo só para erro)
- Props opcionais `pageTitle` / `description` com defaults, para reuso/customização futura
- Remoção de código comentado (exibição da rota via `router.asPath`) — mantém a página simples nesta entrega
- Escopo deliberadamente mínimo: 1 arquivo, sem i18n nem tracking de URL quebrada

## Checklist

- [x] Página 404 customizada no padrão do App (`Layout`)
- [x] Meta tags básicas (title, description, OG)
- [x] CTA de retorno à home
- [x] Sem dependência de libs novas
- [ ] (Follow-up) Exibir a path inválida e/ou link “reportar problema”, se fizer sentido para o produto